### PR TITLE
new security-opt: privileged-without-host-devices

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -99,13 +99,14 @@ type Container struct {
 	attachContext  *attachContext
 
 	// Fields here are specific to Unix platforms
-	AppArmorProfile string
-	HostnamePath    string
-	HostsPath       string
-	ShmPath         string
-	ResolvConfPath  string
-	SeccompProfile  string
-	NoNewPrivileges bool
+	AppArmorProfile              string
+	HostnamePath                 string
+	HostsPath                    string
+	ShmPath                      string
+	ResolvConfPath               string
+	SeccompProfile               string
+	NoNewPrivileges              bool
+	PrivilegedWithoutHostDevices bool
 
 	// Fields here are specific to Windows
 	NetworkSharedContainerID string            `json:"-"`

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -211,6 +211,10 @@ func parseSecurityOpt(container *container.Container, config *containertypes.Hos
 			container.NoNewPrivileges = true
 			continue
 		}
+		if opt == "privileged-without-host-devices" {
+			container.PrivilegedWithoutHostDevices = true
+			continue
+		}
 		if opt == "disable" {
 			labelOpts = append(labelOpts, "disable")
 			continue
@@ -240,6 +244,12 @@ func parseSecurityOpt(container *container.Container, config *containertypes.Hos
 				return fmt.Errorf("invalid --security-opt 2: %q", opt)
 			}
 			container.NoNewPrivileges = noNewPrivileges
+		case "privileged-without-host-devices":
+			pwohd, err := strconv.ParseBool(con[1])
+			if err != nil {
+				return fmt.Errorf("invalid --security-opt 2: %q", opt)
+			}
+			container.PrivilegedWithoutHostDevices = pwohd
 		default:
 			return fmt.Errorf("invalid --security-opt 2: %q", opt)
 		}

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -873,7 +873,10 @@ func WithDevices(daemon *Daemon, c *container.Container) coci.SpecOpts {
 		var devs []specs.LinuxDevice
 		devPermissions := s.Linux.Resources.Devices
 
-		if c.HostConfig.Privileged && !userns.RunningInUserNS() {
+		if c.PrivilegedWithoutHostDevices && !c.HostConfig.Privileged {
+			return errors.New("privileged-without-host-devices requires privileged mode to be enabled")
+		}
+		if c.HostConfig.Privileged && !userns.RunningInUserNS() && !c.PrivilegedWithoutHostDevices {
 			hostDevices, err := devices.HostDevices()
 			if err != nil {
 				return err


### PR DESCRIPTION
`docker run --runtime=kata --privileged` is insecure despite of Kata's VM isolation because host devices are visible to the container.

This commit adds a new security-opt `privileged-without-host-devices` to allow privileged mode without mounting host devices. The daemon returns an error if the opt is specified but privileged is not specified.

A common use-case of this is to run Docker-in-Docker securely.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

